### PR TITLE
remove plugins section from catalogs

### DIFF
--- a/FESOM/FESOM_13_tropo_age_interpolated.yaml
+++ b/FESOM/FESOM_13_tropo_age_interpolated.yaml
@@ -1,7 +1,3 @@
-plugins:
-  source:
-  - module: intake_xarray
-
 sources:
   2D_1h_0.1deg:
     description: 2D variables from FESOM tropo (13km) interpolated to 0.1deg. Only tropical Atlantic.    

--- a/FESOM/IFS_28-FESOM_25-cycle3.yaml
+++ b/FESOM/IFS_28-FESOM_25-cycle3.yaml
@@ -1,6 +1,3 @@
-plugins:
-  source:
-  - module: intake_xarray
 sources:
   2D_1h_native:
     args:

--- a/FESOM/IFS_4.4-FESOM_5-cycle3.yaml
+++ b/FESOM/IFS_4.4-FESOM_5-cycle3.yaml
@@ -1,6 +1,3 @@
-plugins:
-  source:
-  - module: intake_xarray
 sources:
   2D_1h_0.25deg:
     args:

--- a/FESOM/IFS_9-FESOM_5-cycle3.yaml
+++ b/FESOM/IFS_9-FESOM_5-cycle3.yaml
@@ -1,6 +1,3 @@
-plugins:
-  source:
-  - module: intake_xarray
 sources:
   2D_1h_native:
     args:

--- a/FESOM/scripts/IFS_4.4-FESOM_5-cycle3.yaml
+++ b/FESOM/scripts/IFS_4.4-FESOM_5-cycle3.yaml
@@ -7,9 +7,6 @@
 # - 3D_daily_native: salt, temp, Kv, w, u, v, Av
 # - 3D_3h_native: salt_upper, temp_upper, w_upper, u_upper, v_upper
 
-plugins:
-  source:
-  - module: intake_xarray
 sources:
   2D_1h_native:
     args:

--- a/FESOM/scripts/IFS_4.4-FESOM_5-cycle3_interpolated.yaml
+++ b/FESOM/scripts/IFS_4.4-FESOM_5-cycle3_interpolated.yaml
@@ -1,6 +1,3 @@
-plugins:
-  source:
-  - module: intake_xarray
 sources:
   2D_daily_0.25deg:
     description: 2D_daily_0.25deg data

--- a/FESOM/scripts/IFS_4.4-FESOM_5-cycle3_interpolated_monthly.yaml
+++ b/FESOM/scripts/IFS_4.4-FESOM_5-cycle3_interpolated_monthly.yaml
@@ -1,7 +1,3 @@
-plugins:
-  source:
-  - module: intake_xarray
-
 sources:
   3D_monthly_0.25deg:
     description: '3D Monthly Data on 0.25 degree grid'

--- a/FESOM/scripts/IFS_4.4-FESOM_5-cycle3_zarr.yaml
+++ b/FESOM/scripts/IFS_4.4-FESOM_5-cycle3_zarr.yaml
@@ -1,6 +1,3 @@
-plugins:
-  source:
-  - module: intake_xarray
 sources:
   3D_3h_native_zarr:
     args:

--- a/FESOM/scripts/add_metadata.py
+++ b/FESOM/scripts/add_metadata.py
@@ -64,7 +64,6 @@ for source in fcat.keys():
 
 # Save the updated catalog to a new YAML file
 new_catalog = {
-    'plugins': {'source': [{'module': 'intake_xarray'}]},
     'sources': new_sources_dict
 }
 

--- a/FESOM/scripts/build_catalog_IFS_28-FESOM_25-cycle3.py
+++ b/FESOM/scripts/build_catalog_IFS_28-FESOM_25-cycle3.py
@@ -62,7 +62,6 @@ def extract_source(file_name):
 
 # Fixed catalog entries
 fixed_catalog_entries = {
-    "plugins": {"source": [{"module": "intake_xarray"}]},
     "sources": {
         "elem_grid": {
             "args": {

--- a/FESOM/scripts/build_catalog_IFS_4.4-FESOM_5-cycle3.py
+++ b/FESOM/scripts/build_catalog_IFS_4.4-FESOM_5-cycle3.py
@@ -66,7 +66,6 @@ def extract_source(file_name):
 
 # Fixed catalog entries
 fixed_catalog_entries = {
-    "plugins": {"source": [{"module": "intake_xarray"}]},
     "sources": {
         "elem_grid": {
             "args": {"urlpath": "/work/bm1235/a270046/meshes/NG5_griddes_elems_IFS.nc"},

--- a/FESOM/scripts/build_catalog_IFS_4.4-FESOM_5-cycle3_zarr.py
+++ b/FESOM/scripts/build_catalog_IFS_4.4-FESOM_5-cycle3_zarr.py
@@ -23,11 +23,6 @@ def create_intake_catalog(years, variables_daily, variables_hourly, directory):
                     urlpath_hourly.append(file_path)
                 
     catalog_dict = {
-        'plugins': {
-            'source': [
-                {'module': 'intake_xarray'}
-            ]
-        },
         'sources': {
             '3D_daily_native_zarr': {
                 'driver': 'zarr',

--- a/FESOM/scripts/build_catalog_IFS_9-FESOM_5-cycle3.py
+++ b/FESOM/scripts/build_catalog_IFS_9-FESOM_5-cycle3.py
@@ -66,7 +66,6 @@ def extract_source(file_name):
 
 # Fixed catalog entries
 fixed_catalog_entries = {
-    "plugins": {"source": [{"module": "intake_xarray"}]},
     "sources": {
         "elem_grid": {
             "args": {"urlpath": "/work/bm1235/a270046/meshes/NG5_griddes_elems_IFS.nc"},

--- a/FESOM/scripts/combine.py
+++ b/FESOM/scripts/combine.py
@@ -39,11 +39,8 @@ combined_sources = {
     **data_inventory,
 }
 
-# Define the plugins
-plugins = {"source": [{"module": "intake_xarray"}]}
-
 # Prepare the combined catalog
-combined_catalog = {"plugins": plugins, "sources": combined_sources}
+combined_catalog = {"sources": combined_sources}
 
 # Write the combined catalog to a new YAML file
 with open("../IFS_4.4-FESOM_5-cycle3.yaml", "w") as file:

--- a/ICON/main.yaml
+++ b/ICON/main.yaml
@@ -1,6 +1,3 @@
-plugins:
-  source:
-  - module: intake_xarray
 sources:
   ngc4006:
     args:

--- a/ICON/main_fast.yaml
+++ b/ICON/main_fast.yaml
@@ -1,6 +1,3 @@
-plugins:
-  source:
-  - module: intake_xarray
 sources:
   ngc3028:
     args:

--- a/ICON/main_slow.yaml
+++ b/ICON/main_slow.yaml
@@ -1,6 +1,3 @@
-plugins:
-  source:
-  - module: intake_xarray
 sources:
   ngc3028:
     args:

--- a/IFS/tco-grids-cycle3.yaml
+++ b/IFS/tco-grids-cycle3.yaml
@@ -1,6 +1,3 @@
-plugins:
-  source:
-  - module: intake_xarray
 sources:
   native4.4_grid:
     driver: netcdf

--- a/IFS/tco1279-ng5-cycle3.yaml
+++ b/IFS/tco1279-ng5-cycle3.yaml
@@ -1,8 +1,3 @@
-plugins:
-  source:
-    - module: intake_xarray
-    - module: gribscan
-
 sources:
   2D_1h_native:
     driver: zarr

--- a/IFS/tco1279-orca025-cycle3.yaml
+++ b/IFS/tco1279-orca025-cycle3.yaml
@@ -1,8 +1,3 @@
-plugins:
-  source:
-    - module: intake_xarray
-    - module: gribscan
-
 sources:
   2D_1h_native:
     driver: zarr

--- a/IFS/tco2559-ng5-cycle3-fastdata.yaml
+++ b/IFS/tco2559-ng5-cycle3-fastdata.yaml
@@ -1,8 +1,3 @@
-plugins:
-  source:
-    - module: intake_xarray
-    - module: gribscan
-
 sources:
   2D_1h_native:
     driver: zarr

--- a/IFS/tco2559-ng5-cycle3.yaml
+++ b/IFS/tco2559-ng5-cycle3.yaml
@@ -1,8 +1,3 @@
-plugins:
-  source:
-    - module: intake_xarray
-    - module: gribscan
-
 sources:
   2D_1h_native:
     driver: zarr

--- a/IFS/tco399-forca025-cycle3.yaml
+++ b/IFS/tco399-forca025-cycle3.yaml
@@ -1,8 +1,3 @@
-plugins:
-  source:
-    - module: intake_xarray
-    - module: gribscan
-
 sources:
 #  2D_1h_native:
 #    driver: zarr

--- a/IFS/tco399-orca025-cycle3.yaml
+++ b/IFS/tco399-orca025-cycle3.yaml
@@ -1,8 +1,3 @@
-plugins:
-  source:
-    - module: intake_xarray
-    - module: gribscan
-
 sources:
   2D_1h_native:
     driver: zarr

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -14,10 +14,10 @@ sources:
     description: IFS model output
     driver: yaml_file_cat
     args:
-        path: "https://raw.githubusercontent.com/nextGEMS/catalog/main/IFS/main.yaml"
+        path: "{{CATALOG_DIR}}/IFS/main.yaml"
   FESOM:
     description: FESOM ocean model output
     driver: yaml_file_cat
     args:
-        path: "https://raw.githubusercontent.com/nextGEMS/catalog/main/FESOM/main.yaml"
+        path: "{{CATALOG_DIR}}/FESOM/main.yaml"
         


### PR DESCRIPTION
The plugins section was needed in early versions of intake to pre-load libraries required to work with a catalog. This method has been replaced by using different "entry-points" during package install. Apparently, this old method is not working with the current version of intake (i.e. 2.0.1), thus this commit removes is old method.

The relevante modules have been
* intake_xarray (which uses entry-points to register as a driver since version 0.3.1 (Aug 2019)
* gribscan (which uses entry-points since the beginning, but relied on numcodecs, which supports this mechanism since version 0.10.0 (June 2022)

Thus, this change will require that uses have new enough (i.e. less than 1.5 years old) libraries installed, or as a workaround those users will
  have to `import intake_xarray` or `import gribscan` before opening the
  catalog, if they want to keep working on those old versions.