### PR TITLE
add ngc4008 and rename experiment_id to nextgems_prefinal

### DIFF
--- a/ICON/main.yaml
+++ b/ICON/main.yaml
@@ -2,6 +2,43 @@ plugins:
   source:
   - module: intake_xarray
 sources:
+  ngc4008:
+    args:
+      chunks: null
+      consolidated: true
+      urlpath: /work/bm1235/k203123/nextgems_prefinal/experiments/ngc4008/outdata/ngc4008_{{
+        time }}_{{ zoom }}.zarr
+    driver: zarr
+    parameters:
+      time:
+        allowed:
+        - PT15M
+        - PT3H
+        - P1D
+        default: P1D
+        description: time resolution of the dataset
+        type: str
+      zoom:
+        allowed:
+        - 10
+        - 9
+        - 8
+        - 7
+        - 6
+        - 5
+        - 4
+        - 3
+        - 2
+        - 1
+        - 0
+        default: 0
+        description: zoom resolution of the dataset
+        type: int
+    metadata:
+      project: nextGEMS
+      experiment_id: nextgems_prefinal
+      source_id: ICON-ESM
+      simulation_id: ngc4008
   ngc4006:
     args:
       chunks: null
@@ -36,7 +73,7 @@ sources:
         type: int
     metadata:
       project: nextGEMS
-      experiment_id: nextgems_cycle4
+      experiment_id: nextgems_prefinal
       source_id: ICON-ESM
       simulation_id: ngc4006
   ngc4005:
@@ -76,7 +113,7 @@ sources:
         type: int
     metadata:
       project: nextGEMS
-      experiment_id: nextgems_cycle4
+      experiment_id: nextgems_prefinal
       source_id: ICON-ESM
       simulation_id: ngc4005
   ngc3028:


### PR DESCRIPTION
As far as I understood, prefinal is the new name of the beast.