### PR TITLE
fix monthly means for first 20 years of H512

### DIFF
--- a/IFS/tco1279-ng5-production-years.yaml
+++ b/IFS/tco1279-ng5-production-years.yaml
@@ -6,6 +6,7 @@ sources:
       urlpath: 
       - reference::/work/bm1235/a270046/cycle4/gribscan_1h1d_2D_healpix512/jsons.2020/sfc.dir/atm2d.json
       - reference::/work/bm1235/a270046/cycle4/gribscan_1h1d_2D_healpix512/jsons.2021/sfc.dir/atm2d.json
+      drop_variables: ['sst', 'ci', '10si', '100si']  
   2D_daily_healpix512_ocean:
     driver: zarr
     args:
@@ -43,7 +44,8 @@ sources:
       urlpath:
       - reference::/work/bm1235/a270046/cycle4/gribscan_monthly_healpix512/jsons.2020-2030/sfc.dir/atm2d.json
       - reference::/work/bm1235/a270046/cycle4/gribscan_monthly_healpix512/jsons.2030-2034/sfc.dir/atm2d.json
-      - reference::/work/bm1235/a270046/cycle4/gribscan_monthly_healpix512/jsons.2035-2039/sfc.dir/atm2d.json 
+      - reference::/work/bm1235/a270046/cycle4/gribscan_monthly_healpix512/jsons.2035-2039/sfc.dir/atm2d.json
+      drop_variables: ['sst', 'ci', '10si', '100si']  
   3D_monthly_healpix512:
     driver: zarr
     args:


### PR DESCRIPTION
Dropping problematic variables for surface variables,

`drop_variables: ['sst', 'ci', '10si', '100si']`

because they changed/were added over the course of the simulation. This resulted in the issue:

```
PerformanceWarning: Slicing is producing a large chunk. To accept the large
chunk and silence this warning, set the option
    >>> with dask.config.set(**{'array.slicing.split_large_chunks': False}):
    ...     array[indexer]
``` 

as also seen by @TobiasBkr 

Works now to load all 20 years at once:

![image](https://github.com/nextGEMS/catalog/assets/26135424/7cb65625-f847-4334-b049-e565bf7081b5)
