### PR TITLE
New directory for ngc4008 with rechunked output for low levels.

### DIFF
--- a/ICON/main.yaml
+++ b/ICON/main.yaml
@@ -3,7 +3,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: /work/bm1235/k203123/nextgems_prefinal/experiments/ngc4008/outdata/ngc4008_{{
+      urlpath: /work/bm1235/k202181/ngc4008/ngc4008_{{
         time }}_{{ zoom }}.zarr
     driver: zarr
     parameters:


### PR DESCRIPTION
Use new directory for ngc4008 which links to the raw output for high levels and rechunked output for low levels.