### PR TITLE
Prune icon ngc4

### DIFF
--- a/ICON/C5.yaml
+++ b/ICON/C5.yaml
@@ -3,7 +3,7 @@ sources:
     description: ICON-AMIP simulations for the C5 project.
     args:
       urlpath:
-        - "/scratch/m/m300575/LUMI_AMIP_{{ grid }}_{{ experiment }}/LUMI_AMIP_hpz{{ zoom }}_{{ experiment }}_atm_2d_{{ time }}_ml_*.nc"
+        - "/scratch/m/m300575/LUMI_AMIP_{{ grid }}_CNTL/LUMI_AMIP_hpz{{ zoom }}_CNTL_atm_2d_{{ time }}_ml_*.nc"
     driver: netcdf
     parameters:
       grid:
@@ -11,12 +11,6 @@ sources:
           - R02B08
         default: R02B08
         description: original model grid used for computation
-        type: str
-      experiment:
-        allowed:
-          - CNTL
-        default: CNTL
-        description: simulation type
         type: str
       time:
         allowed:
@@ -34,3 +28,5 @@ sources:
     metadata:
       project: Cloud-Circulation Coupling in a Changing Climate (C5)
       source_id: ICON-AMIP
+      experiment_id: AMIP
+      simulation_id: CNTL

--- a/ICON/C5.yaml
+++ b/ICON/C5.yaml
@@ -1,6 +1,6 @@
 sources:
-  AMIP:
-    description: ICON-AMIP simulations for the C5 project.
+  AMIP_CNTL:
+    description: ICON-AMIP Control simulation(s) for the C5 project.
     args:
       urlpath:
         - "/scratch/m/m300575/LUMI_AMIP_{{ grid }}_CNTL/LUMI_AMIP_hpz{{ zoom }}_CNTL_atm_2d_{{ time }}_ml_*.nc"

--- a/ICON/main.yaml
+++ b/ICON/main.yaml
@@ -91,7 +91,6 @@ sources:
         type: str
       zoom:
         allowed:
-        - 10
         - 9
         - 8
         - 7
@@ -128,7 +127,6 @@ sources:
         type: str
       zoom:
         allowed:
-        - 10
         - 9
         - 8
         - 7
@@ -168,7 +166,6 @@ sources:
         type: str
       zoom:
         allowed:
-        - 10
         - 9
         - 8
         - 7

--- a/ICON/main.yaml
+++ b/ICON/main.yaml
@@ -17,7 +17,6 @@ sources:
         type: str
       zoom:
         allowed:
-        - 10
         - 9
         - 8
         - 7


### PR DESCRIPTION
removed level 10 from ngc400[567]
reformatted C5 data (btw. this is on /scratch/) - I think we should have only one simulation per dataset (also was the case before). Otherwise we create a bit too much diversity in the catalog structure.