### PR TITLE
2D_hourly_healpix512 provides lat and lon with 'values' as single dim…

### DIFF
--- a/IFS/tco1279-ng5-production-years.yaml
+++ b/IFS/tco1279-ng5-production-years.yaml
@@ -4,7 +4,7 @@ sources:
     args:
       consolidated: False
       urlpath:
-        - reference::/scratch/m/m300827/IFS_9-FESOM_5-production_2d_hourly_healpix512_combined.parq
+        - reference::/work/bm1235/b382776/cycle4/parquets/IFS_9-FESOM_5-production_2d_hourly_healpix512_combined_V2.parq
   2D_hourly_healpix512_2020s:
     driver: zarr
     args:


### PR DESCRIPTION
Loading the previous parquet through xarray showed lat and lon  to have (time, values) as dimension. Now lat lon only have (values) as dimension, since lat and lon are constant over time.