### PR TITLE
IFS parquet references: explicitly state remote_protocol

### DIFF
--- a/IFS/tco1279-ng5-production-years.yaml
+++ b/IFS/tco1279-ng5-production-years.yaml
@@ -5,6 +5,8 @@ sources:
       consolidated: False
       urlpath:
         - reference::/work/bm1235/b382776/cycle4/parquets/IFS_9-FESOM_5-production_2d_hourly_healpix512_combined_V2.parq
+      storage_options:
+        remote_protocol: file
   2D_hourly_healpix512_2020s:
     driver: zarr
     args:
@@ -95,6 +97,8 @@ sources:
       consolidated: False
       urlpath:
         - reference::/scratch/m/m300827/IFS_9-FESOM_5-production_3d_hourly_healpix512_combined.parq
+      storage_options:
+        remote_protocol: file
   3D_hourly_healpix512_2020:
     driver: zarr
     args:


### PR DESCRIPTION
The reference filesystem implementation needs to know in advance which (fsspec-) protocol(s) is used to access data chunks in referenced files. There is a heuristic in place, but this heuristic apparently fails in some cases. As we know that the references are (currently) backed by files on the filessystem, we can just fix the protocol to "file" to work around this issue (and possible improve performance slightly).