### PR TITLE
fixed paths in IFS_9-FESOM_5-production-hist catalog

### DIFF
--- a/IFS/tco1279-ng5-production-hist-years.yaml
+++ b/IFS/tco1279-ng5-production-hist-years.yaml
@@ -146,7 +146,7 @@ sources:
     args:
       consolidated: False
       urlpath:
-      - reference::/work/bm1235/b381679/cycle4_hist/gribscan_1h1d_2D_healpix128/jsons.1990/sfc.dir/atm2d.json
+      - reference::/work/bm1235/u233156/cycle4_hist/gribscan_1h1d_2D_healpix128/jsons.1990/sfc.dir/atm2d.json
       - reference::/work/bm1235/u233156/cycle4_hist/gribscan_1h1d_2D_healpix128/jsons.1991/sfc.dir/atm2d.json
       - reference::/work/bm1235/u233156/cycle4_hist/gribscan_1h1d_2D_healpix128/jsons.1992/sfc.dir/atm2d.json
       - reference::/work/bm1235/u233156/cycle4_hist/gribscan_1h1d_2D_healpix128/jsons.1993/sfc.dir/atm2d.json
@@ -257,7 +257,7 @@ sources:
     args:
       consolidated: False
       urlpath:
-      - reference::/work/bm1235/b381679/cycle4_hist/gribscan_1h1d_2D_latlon/jsons.1990/pl.dir/atm3d.json
+      - reference::/work/bm1235/u233156/cycle4_hist/gribscan_1h1d_2D_latlon/jsons.1990/pl.dir/atm3d.json
       - reference::/work/bm1235/u233156/cycle4_hist/gribscan_1h1d_2D_latlon/jsons.1991/pl.dir/atm3d.json
       - reference::/work/bm1235/u233156/cycle4_hist/gribscan_1h1d_2D_latlon/jsons.1992/pl.dir/atm3d.json
       - reference::/work/bm1235/u233156/cycle4_hist/gribscan_1h1d_2D_latlon/jsons.1993/pl.dir/atm3d.json
@@ -272,7 +272,7 @@ sources:
     args:
       consolidated: False
       urlpath:
-      - reference::/work/bm1235/b381679/cycle4_hist/gribscan_1h1d_2D_latlon/jsons.1990/sfc.dir/atm2d.json
+      - reference::/work/bm1235/u233156/cycle4_hist/gribscan_1h1d_2D_latlon/jsons.1990/sfc.dir/atm2d.json
       - reference::/work/bm1235/u233156/cycle4_hist/gribscan_1h1d_2D_latlon/jsons.1991/sfc.dir/atm2d.json
       - reference::/work/bm1235/u233156/cycle4_hist/gribscan_1h1d_2D_latlon/jsons.1992/sfc.dir/atm2d.json
       - reference::/work/bm1235/u233156/cycle4_hist/gribscan_1h1d_2D_latlon/jsons.1993/sfc.dir/atm2d.json


### PR DESCRIPTION
fixed paths for 2D_hourly_healpix128, 3D_hourly_0.25deg_1990s, 2D_hourly_0.25deg in IFS_9-FESOM_5-production-hist