### PR TITLE
Fix urlpath for NextGEMS Cycle 4 (ngc4008)

### DIFF
--- a/ICON/main.yaml
+++ b/ICON/main.yaml
@@ -39,7 +39,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: /work/bm1235/k202181/ngc4008/ngc4008_{{
+      urlpath: /work/kd1453/rechunked_ngc4008/ngc4008_{{
         time }}_{{ zoom }}.zarr
     driver: zarr
     parameters:


### PR DESCRIPTION
This PR fixes the catalog based on the following Mattermost message:

> I moved the directory /work/bm1235/k202181/rechunked_ngc4008 to /work/kd1453/rechunked_ngc4008. So you might need to adapt your nextGEMS catalog.