### PR TITLE
Update main.yaml

### DIFF
--- a/ICON/main.yaml
+++ b/ICON/main.yaml
@@ -39,7 +39,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: /work/bm1235/k202134/zarr_with_fixed_zmetadata/ngc4008_{{
+      urlpath: /work/kd1453/rechunked_ngc4008/ngc4008_{{
         time }}_{{ zoom }}.zarr
     driver: zarr
     parameters:


### PR DESCRIPTION
missing NaN values are corrected in the dataset itself, therefore the catalog can point back to the original data