### PR TITLE
add two new catalogs for IFS Cycle 4 

### DIFF
--- a/IFS/main.yaml
+++ b/IFS/main.yaml
@@ -1,10 +1,20 @@
 sources:
   IFS_9-FESOM_5-production:
+    description: main 9km scenario (SSP3-7.0), coupled with FESOM 5km, updated gribscan
+    driver: yaml_file_cat
+    args:
+        path: "{{CATALOG_DIR}}/tco1279-ng5-production-updated-gribscan-years.yaml"
+  IFS_9-FESOM_5-production-hist:
+    description: main 9km historical (starting 1990), coupled with FESOM 5km, updated gribscan
+    driver: yaml_file_cat
+    args:
+        path: "{{CATALOG_DIR}}/tco1279-ng5-production-hist-updated-gribscan-years.yaml"
+  IFS_9-FESOM_5-production-old-gribscan:
     description: main 9km scenario (SSP3-7.0), coupled with FESOM 5km, purged
     driver: yaml_file_cat
     args:
         path: "{{CATALOG_DIR}}/tco1279-ng5-production-purged-years.yaml"
-  IFS_9-FESOM_5-production-hist:
+  IFS_9-FESOM_5-production-hist-old-gribscan:
     description: main 9km historical (starting 1990), coupled with FESOM 5km
     driver: yaml_file_cat
     args:


### PR DESCRIPTION
add two new catalogs for IFS Cycle 4 projection and hist with updated gribscan, making them the new defaults