### PR TITLE
Update main_online.yaml

### DIFF
--- a/ICON/main_online.yaml
+++ b/ICON/main_online.yaml
@@ -31,7 +31,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://eerie.cloud.dkrz.de/datasets/nextgems.ICON.ngc4008.{{ time }}_{{ zoom }}/kerchunk
+      urlpath: https://s3.eu-dkrz-1.dkrz.cloud/nextgems/rechunked_ngc4008/ngc4008_{{ time }}_{{ zoom }}.zarr
     driver: zarr
     parameters:
       time:


### PR DESCRIPTION
serving from s3 via https instead of levante via xpublish