### PR TITLE
Add ERA5, JRA3Q and MERRA2 reanalyses

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -17,7 +17,7 @@ sources:
   ERA5:
     args:
       consolidated: true
-      urlpath: swift://swift.dkrz.de/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/ERA5_P1M_{{ zoom }}.zarr
+      urlpath: https://swift.dkrz.de/v1/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/ERA5_P1M_{{ zoom }}.zarr
     driver: zarr
     parameters:
       zoom:
@@ -28,7 +28,7 @@ sources:
   JRA3Q:
     args:
       consolidated: true
-      urlpath: swift://swift.dkrz.de/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/JRA3Q_P1M_{{ zoom }}.zarr
+      urlpath: https://swift.dkrz.de/v1/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/JRA3Q_P1M_{{ zoom }}.zarr
     driver: zarr
     parameters:
       zoom:
@@ -39,5 +39,5 @@ sources:
   MERRA2:
     args:
       consolidated: true
-      urlpath: swift://swift.dkrz.de/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/MERRA2_P1M_7.zarr
+      urlpath: https://swift.dkrz.de/v1/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/MERRA2_P1M_7.zarr
     driver: zarr

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -14,3 +14,30 @@ sources:
     driver: yaml_file_cat
     args:
         path: "{{CATALOG_DIR}}/FESOM/main.yaml"
+  ERA5:
+    args:
+      consolidated: true
+      urlpath: swift://swift.dkrz.de/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/ERA5_P1M_{{ zoom }}.zarr
+    driver: zarr
+    parameters:
+      zoom:
+        allowed: [8, 7]
+        default: 7
+        description: zoom resolution of the dataset
+        type: int
+  JRA3Q:
+    args:
+      consolidated: true
+      urlpath: swift://swift.dkrz.de/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/JRA3Q_P1M_{{ zoom }}.zarr
+    driver: zarr
+    parameters:
+      zoom:
+        allowed: [8, 7]
+        default: 7
+        description: zoom resolution of the dataset
+        type: int
+  MERRA2:
+    args:
+      consolidated: true
+      urlpath: swift://swift.dkrz.de/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/MERRA2_P1M_7.zarr
+    driver: zarr

--- a/online.yaml
+++ b/online.yaml
@@ -4,3 +4,30 @@ sources:
     driver: yaml_file_cat
     args:
         path: "{{CATALOG_DIR}}/ICON/main_online.yaml"
+  ERA5:
+    args:
+      consolidated: true
+      urlpath: https://swift.dkrz.de/v1/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/ERA5_P1M_{{ zoom }}.zarr
+    driver: zarr
+    parameters:
+      zoom:
+        allowed: [8, 7]
+        default: 7
+        description: zoom resolution of the dataset
+        type: int
+  JRA3Q:
+    args:
+      consolidated: true
+      urlpath: https://swift.dkrz.de/v1/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/JRA3Q_P1M_{{ zoom }}.zarr
+    driver: zarr
+    parameters:
+      zoom:
+        allowed: [8, 7]
+        default: 7
+        description: zoom resolution of the dataset
+        type: int
+  MERRA2:
+    args:
+      consolidated: true
+      urlpath: https://swift.dkrz.de/v1/dkrz_41caca03ec414c2f95f52b23b775134f/reanalysis/v1/MERRA2_P1M_7.zarr
+    driver: zarr


### PR DESCRIPTION
This PR adds the monthly mean data sets of ERA5, JRA3Q and MERRA2 (all on HEALPix).