### PR TITLE
add IFS_2.8-AMIP: atmosphere-only IFS at tco3999, using cycle4 config and output

### DIFF
--- a/IFS/main.yaml
+++ b/IFS/main.yaml
@@ -1,4 +1,9 @@
 sources:
+  IFS_2.8-AMIP:
+    description: 2.8 km IFS, atmosphere-only (AMIP), with reduced cloud base mass flux (RCBMF) in the deep convection scheme. Forced with ESA CCI v3.0.1 SST and sea ice concentration
+    driver: yaml_file_cat
+    args:
+        path: "{{CATALOG_DIR}}/tco3999-amip.yaml"
   IFS_2.8-FESOM_5-production-deep-off:
     description: 2.8 km IFS with Deep Off, coupled with FESOM 5km
     driver: yaml_file_cat

--- a/IFS/tco3999-amip.yaml
+++ b/IFS/tco3999-amip.yaml
@@ -1,0 +1,64 @@
+sources:
+  2D_hourly_healpix2048:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco3999-ng-rcbmf_end/2D_hourly_healpix2048.parq
+  3D_hourly_healpix2048:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco3999-ng-rcbmf_end/3D_hourly_healpix2048.parq
+  # 3D_hourly_healpix2048_snow:
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath: 
+  #     - reference::/work/bm1235/u233156/gribscan_cycle4_3999_RCBMF/gribscan_1h1d_2D_healpix2048/jsons/sol.dir/atm2d.json       !        
+  2D_monthly_healpix2048:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco3999-ng-rcbmf_end/2D_monthly_healpix2048.parq
+  2D_hourly_healpix128:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco3999-ng-rcbmf_end/2D_hourly_healpix128.parq
+  3D_hourly_healpix128:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco3999-ng-rcbmf_end/3D_hourly_healpix128.parq
+  # 3D_hourly_healpix128_snow:
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath: 
+  #     - reference::/work/bm1235/u233156/gribscan_cycle4_3999_RCBMF/gribscan_1h1d_2D_healpix128/jsons/sol.dir/atm2d.json        !                         
+  2D_monthly_healpix128:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco3999-ng-rcbmf_end/2D_monthly_healpix128.parq
+  2D_hourly_0.25deg:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco3999-ng-rcbmf_end/2D_hourly_0.25deg.parq
+  3D_hourly_0.25deg:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco3999-ng-rcbmf_end/3D_hourly_0.25deg.parq
+  # 3D_hourly_0.25deg_snow:
+  #   driver: zarr
+  #   args:
+  #     consolidated: False
+  #     urlpath: 
+  #     - reference::/work/bm1235/u233156/gribscan_cycle4_3999_RCBMF/gribscan_1h1d_2D_latlon/jsons/sol.dir/atm2d.json     !                           
+  2D_monthly_0.25deg:
+    driver: zarr    
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco3999-ng-rcbmf_end/2D_monthly_0.25deg.parq


### PR DESCRIPTION
@trackow 