### PR TITLE
add IFS_4.4-AMIP: atmosphere-only IFS at tco2559, using EERIE config, rcbmf

### DIFF
--- a/IFS/main.yaml
+++ b/IFS/main.yaml
@@ -4,6 +4,11 @@ sources:
     driver: yaml_file_cat
     args:
         path: "{{CATALOG_DIR}}/tco3999-amip.yaml"
+  IFS_4.4-AMIP:
+    description: 4.4 km IFS, atmosphere-only (AMIP), with reduced cloud base mass flux (RCBMF) in the deep convection scheme. Forced with ESA CCI v3.0.1 SST and sea ice concentration
+    driver: yaml_file_cat
+    args:
+        path: "{{CATALOG_DIR}}/tco2559-amip.yaml"
   IFS_2.8-FESOM_5-production-deep-off:
     description: 2.8 km IFS with Deep Off, coupled with FESOM 5km
     driver: yaml_file_cat

--- a/IFS/tco2559-amip.yaml
+++ b/IFS/tco2559-amip.yaml
@@ -1,0 +1,91 @@
+sources:
+  2D_hourly_healpix1024:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/2D_hourly_healpix1024.parq
+  3D_hourly_healpix1024:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/3D_hourly_healpix1024.parq
+  2D_daily_healpix1024:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/2D_daily_healpix1024.parq
+  3D_daily_healpix1024:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/3D_daily_healpix1024.parq
+  2D_monthly_healpix1024:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/2D_monthly_healpix1024.parq
+  3D_monthly_healpix1024:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/3D_monthly_healpix1024.parq
+  2D_hourly_healpix128:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/2D_hourly_healpix128.parq
+  3D_hourly_healpix128:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/3D_hourly_healpix128.parq
+  2D_daily_healpix128:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/2D_daily_healpix128.parq
+  3D_daily_healpix128:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/3D_daily_healpix128.parq
+  2D_monthly_healpix128:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/2D_monthly_healpix128.parq
+  3D_monthly_healpix128:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/3D_monthly_healpix128.parq
+  2D_hourly_0.25deg:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/2D_hourly_0.25deg.parq
+  3D_hourly_0.25deg:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/3D_hourly_0.25deg.parq
+  2D_daily_0.25deg:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/2D_daily_0.25deg.parq
+  3D_daily_0.25deg:
+    driver: zarr
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/3D_daily_0.25deg.parq
+  2D_monthly_0.25deg:
+    driver: zarr    
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/2D_monthly_0.25deg.parq
+  3D_monthly_0.25deg:
+    driver: zarr    
+    args:
+      consolidated: False
+      urlpath: reference::/work/bm1235/b382473/IFS_AMIP/production/parquets/tco2559-eerie_production_202407-rcbmf_end/3D_monthly_0.25deg.parq


### PR DESCRIPTION
- 14 month IFS-AMIP simulation with reduced cloud base mass flux
- atmosphere-only forced with ESA-CCI v3.0.1 SST & sea ice concentration
- done as part of EERIE project
- not that unlike the tco3999 runs, the interpolation from native model output to healpix is NOT conservative
- this catalog entry is formatted "nextGEMS-style", in particular with the time-axis located at the end of the (accumulation, averaging) interval
- some variables were only written for the latter half of the run, they are not included here
- see the EERIE catalog for full data, and EERIE-style catalog formatting: https://github.com/eerie-project/intake_catalogues/tree/main/dkrz/disk/model-output/ifs-amip-tco2559

@trackow 