### PR TITLE
Update URL path and time method in main.yaml

### DIFF
--- a/ICON/main.yaml
+++ b/ICON/main.yaml
@@ -3,7 +3,7 @@ sources:
     args:
       chunks: null
       consolidated: true
-      urlpath: https://s3.eu-dkrz-1.dkrz.cloud/wrcp-hackathon/data/ICON/d3hp003.zarr/{{ time }}_{{ time_method }}_z{{ zoom }}_atm
+      urlpath: /work/bm1235/k203123/dy3ha-p/experiments/d3hp003/outdata/d3hp003_orig.zarr/{{ time }}_{{ time_method }}_z{{ zoom }}_atm
     driver: zarr
     description: Atmosphere-only simulation at 2.5 km resolution
     parameters:
@@ -19,7 +19,7 @@ sources:
       time_method:
         allowed:
           - mean
-          - inst
+          - point
         default: mean
         description: time subsetting method
         type: str


### PR DESCRIPTION
Change d3hp003 offline catalog to point to lustre dataset Updated URL path and zoom levels in main.yaml.
As the S3 is and most likely stays offline for some time, the offline catalog should still be working thus pointing to the dataset on lustre. Will still break old scripts as the naming changed for zoom and inst -> point.